### PR TITLE
[feature] RactorSendReceive auto correction

### DIFF
--- a/lib/rubocop/cop/style/ractor_send_receive.rb
+++ b/lib/rubocop/cop/style/ractor_send_receive.rb
@@ -5,6 +5,8 @@ module RuboCop
   module Cop
     module Style
       class RactorSendReceive < Base
+        extend AutoCorrector
+
         MSG = 'Ractor.receive detected in the Ractor block '\
               'but no corresponding `%<ractor>s`.send found.'.freeze
 
@@ -35,7 +37,9 @@ module RuboCop
           return if checker.receive_paired_with_send?(node)
 
           message = message(node)
-          add_offense(node, message: message)
+          add_offense(node, message: message) do |corrector|
+            corrector.insert_after(node, "\n\n#{node.children[0]}.send()")
+          end
         end
 
         private


### PR DESCRIPTION
### 1. 概要
custom copであるStyle/RactorSendReceiveのautocorrect機能の追加を行います。

### 2. 仕様
以下のような、Ractorブロック内に`Ractor.receive`があり、当該Ractorブロック以降でRactor aに対するsend命令の記述がない場合に、Ractorブロックのendの2行先に`a.send()`のように記述を追加します。
また、`a.send()`のaの部分についてはRactor.newが格納された変数の名前に合わせて記述を行います。
```
a = Ractor.new do
  b = Ractor.receive
  ...
end
```
