### PR TITLE
[feature] RactorReceiveSend autocorrect

### DIFF
--- a/lib/rubocop/cop/style/ractor_receive_send.rb
+++ b/lib/rubocop/cop/style/ractor_receive_send.rb
@@ -19,10 +19,6 @@ module RuboCop
           )
         PATTERN
 
-        def_node_search :ractor_new?, <<~PATTERN
-          (send (const nil? :Ractor) :new)
-        PATTERN
-
         def_node_search :ractor_send?, <<~PATTERN
           (send (lvar _) :send ...)
         PATTERN


### PR DESCRIPTION
### 1. 概要
RactorReceiveSendのautocorrect機能を実装します。

### 2. 仕様
以下の例のように、r1のRactorにsend処理を行っているが、Ractorブロック内にRactor.receiveが存在しない場合にRactorブロック内にRactor.receiveを追記する。
```
  r1 = Ractor.new do
    bubble_sort(smaller_part)
    smaller_part
  end

  r1.send(array[...branch_point])
```